### PR TITLE
Supports multi style / link into head or body section

### DIFF
--- a/InlineStyle/InlineStyle.php
+++ b/InlineStyle/InlineStyle.php
@@ -199,9 +199,16 @@ class InlineStyle
         }
 
         if($node->hasChildNodes()) {
-            foreach($node->childNodes as $child) {
-                $stylesheets = array_merge($stylesheets,
-                    $this->extractStylesheets($child, $base));
+            //Copy child nodes into an array to prevent node destruction
+            $childNodes = array();
+            for($i = 0; $i < $node->childNodes->length; ++$i){
+                $childNodes[] = $node->childNodes->item($i);
+            }
+            foreach($childNodes as $child){
+                $stylesheets = array_merge(
+                    $stylesheets,
+                    $this->extractStylesheets($child, $base)
+                );
             }
         }
 


### PR DESCRIPTION
In this case : 

``` html
<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <title>StyleInliner test</title>
    <style type="text/css">
        p{
            color: red;
        }
    </style>
    <link href="css/style.css" rel="stylesheet" type="text/css" media="all">
</head>
```

Only "style" is used. External stylesheet "css/style.css" is not added to the current styles and not removed from hml.
