### PR TITLE
Assume HTML if strlen($html) > max path length.

### DIFF
--- a/InlineStyle/InlineStyle.php
+++ b/InlineStyle/InlineStyle.php
@@ -52,7 +52,7 @@ class InlineStyle
     public function __construct($html = '')
     {
         if ($html) {
-            if (file_exists($html))
+            if (strlen($html) <= PHP_MAXPATHLEN && file_exists($html))
                 $this->loadHTMLFile($html);
             else
                 $this->loadHTML($html);


### PR DESCRIPTION
Fixes warning:

> file_exists(): File name is longer than the maximum allowed path length on this platform (4096): ...
