### PR TITLE
Fix regression test and sort order for identical selectors (#14)

### DIFF
--- a/InlineStyle/InlineStyle.php
+++ b/InlineStyle/InlineStyle.php
@@ -277,7 +277,7 @@ class InlineStyle
                 return $a[$i] < $b[$i] ? -1 : 1;
             }
         }
-        return 1;
+        return -1;
     }
 
     public function getScoreForSelector($selector)

--- a/InlineStyle/Tests/InlineStyleTest.php
+++ b/InlineStyle/Tests/InlineStyleTest.php
@@ -230,11 +230,11 @@ CSS
         $this->assertEquals(array(
                 array(
                     'ul',
-                    'color: red'
+                    'color: blue'
                 ),
                 array(
                     'ul',
-                    'color: blue'
+                    'color: red'
                 ),
                 array(
                     'ul.class',


### PR DESCRIPTION
@christiaan the fix applied in #14 by @csnover doesn't actually work - the intention is correct, but your regression test seems to cater to the given solution, not the needed one. If you give this as input:

``` css
ul { color: blue; }
ul { color: red; }
```

We would expect the resultant inline rule to be `color: red`, correct?
Simply returning 1 instead of 0 in this case _actually_ means that the earlier selector is considered 'greater than' later selectors, and is thus bumped _down_ the sort order so that it is always sorted _after_ later rules instead of _before_.

The confusion may have come about from a version prior to the fix in #7, which altered the merge order? Not sure.

I've updated the regression test as well.
