### PR TITLE
Add test for issue #28 multiple stylesheets

### DIFF
--- a/InlineStyle/Tests/InlineStyleTest.php
+++ b/InlineStyle/Tests/InlineStyleTest.php
@@ -291,4 +291,24 @@ HTML;
 }');
         $this->assertEquals($expected, $htmldoc->getHTML());
     }
+
+    function testMultipleStylesheets28() {
+        $htmldoc = new InlineStyle(file_get_contents($this->basedir . '/testMultipleStylesheets.html'));
+        $htmldoc->applyStylesheet($htmldoc->extractStylesheets(null, $this->basedir));
+        $expected = <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+<head>
+<title>Example</title>
+</head>
+<body>
+<p style='margin:0;padding:0 0 10px 0;background-image: url("someimage.jpg")'>Paragraph</p>
+<strong style="font-weight: bold">Strong</strong>
+<br>
+</body>
+</html>
+
+HTML;
+        $this->assertEquals($expected, $htmldoc->getHTML());
+    }
 }

--- a/InlineStyle/Tests/testfiles/external2.css
+++ b/InlineStyle/Tests/testfiles/external2.css
@@ -1,0 +1,3 @@
+strong {
+    font-weight: bold;
+}

--- a/InlineStyle/Tests/testfiles/testMultipleStylesheets.html
+++ b/InlineStyle/Tests/testfiles/testMultipleStylesheets.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+<head>
+<title>Example</title>
+<link rel="stylesheet" href="external.css">
+<link rel="stylesheet" href="external2.css">
+</head>
+<body>
+<p>Paragraph</p>
+<strong>Strong</strong>
+<br>
+</body>
+</html>


### PR DESCRIPTION
A solution for this issue might be placing the removeChild actions somewhere out of the iteration. It would also be nice if removeChild were optional in case you still want the external stylesheet references to be there at the end.
